### PR TITLE
Fix the incorrect usage of the demo

### DIFF
--- a/lindormsql-python/demo.py
+++ b/lindormsql-python/demo.py
@@ -12,7 +12,7 @@ def connect(kw_args):
 
 
 # 用户名通过lindorm_user字段传递，密码使用lindorm_password字段设置，database字段设置连接初始化默认数据库。
-connect_kw_args = {'lindorm_user': 'test', 'lindorm_password': 'test', 'database': 'default'}
+connect_kw_args = {'user': 'test', 'password': 'test'}
 connection = connect(connect_kw_args)
 
 with connection.cursor() as statement:


### PR DESCRIPTION
According to the code sample of  [Application Reference of Lindorm](https://help.aliyun.com/document_detail/261165.htm#concept-2088132),  the configuration field names of the connect are incorrect. Besides, the phoenixdb does not support the `database` field in the connect configuration

Fix them with this commit in case of misleading.